### PR TITLE
Making sure that we always return a string when we call get value.

### DIFF
--- a/src/Spreadsheet/PHPExcel/Cell.php
+++ b/src/Spreadsheet/PHPExcel/Cell.php
@@ -66,7 +66,7 @@ class Cell implements CellInterface
      */
     public function getContent() : string
     {
-        return $this->adapterCell->getValue();
+        return (string) $this->adapterCell->getValue();
     }
 
     /**


### PR DESCRIPTION
# What this PR changes:
- Make sure that when we call `getValue()` always return a string.

For some reason while testing`getValue()` from CellInterface, it was returning a float/int instead of string when working with numbers.
# When reviewing, please consider:
- Nothing.
